### PR TITLE
Add T2 temperature sensor mappings for MacBookPro15,1

### DIFF
--- a/src/gui/App.cs
+++ b/src/gui/App.cs
@@ -1716,7 +1716,7 @@ namespace RPMac {
             // Enumerar todo el espacio de claves del SMC es lento, así que se hace una sola
             // vez y se guarda: al rehacer la página (al nombrar un sensor) se reutiliza.
             if (rawKeys.Count > 0) {
-                foreach (var k in rawKeys) allPanel.Children.Add(TempRow(k, k, allLabels, 200));
+                foreach (var k in rawKeys) allPanel.Children.Add(TempRow(k, Smc.TempName(k), allLabels, 200));
                 FillCustomKeyCombo();
                 return;
             }
@@ -1726,7 +1726,8 @@ namespace RPMac {
                 Dispatcher.Invoke((Action)delegate {
                     allPanel.Children.Clear();
                     rawKeys.Clear();
-                    foreach (var k in keys) { rawKeys.Add(k); allPanel.Children.Add(TempRow(k, k, allLabels, 200)); }
+                    foreach (var k in keys) { rawKeys.Add(k); allPanel.Children.Add(TempRow(k, Smc.TempName(k), allLabels, 200));
+                    }
                     FillCustomKeyCombo();
                 });
             }) { IsBackground = true }.Start();

--- a/src/gui/Smc.cs
+++ b/src/gui/Smc.cs
@@ -461,6 +461,54 @@ namespace RPMac {
         }
 
         // ---- API publica ----
+        // ---- Temperature sensor names ----
+        // Human-readable names for known Apple SMC temperature keys.
+        // Includes additional sensors found on T2 Macs, especially MacBookPro15,1.
+
+        static readonly Dictionary<string, string> TempSensorNames =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+
+                // ---- CPU: T2 / MacBookPro15,1 ----
+                { "TC1C", "CPU Core 1" },
+                { "TC2C", "CPU Core 2" },
+                { "TC3C", "CPU Core 3" },
+                { "TC4C", "CPU Core 4" },
+                { "TC5C", "CPU Core 5" },
+                { "TC6C", "CPU Core 6" },
+                { "TCSA", "CPU System Agent" },
+                { "TCXC", "CPU PECI" },
+                { "TCOE", "CPU Core Temp" },
+                { "TCOF", "CPU Die Temp" },
+
+                // ---- GPU ----
+                { "TGDD", "GPU Memory" },
+                { "TGDF", "GPU VRM" },
+                { "TGVP", "GPU Voltage" },
+
+                // ---- Battery ----
+                { "TB1T", "Battery Sensor 1" },
+                { "TB2T", "Battery Sensor 2" },
+
+                // ---- Cooling / Airflow ----
+                { "TF0S", "Fan Intake" },
+
+                // ---- Storage ----
+                { "TH0F", "NVMe SSD" },
+                { "TH0X", "NVMe SSD Controller" }
+            };
+
+        /// <summary>
+        /// Returns a human-readable name for a known temperature sensor.
+        /// Falls back to the raw SMC key when no mapping exists.
+        /// </summary>
+        public static string TempName(string key) {
+            if (string.IsNullOrEmpty(key))
+                return key;
+
+            string name;
+            return TempSensorNames.TryGetValue(key, out name) ? name : key;
+        }
+        
         public static int FanCount() { lock (gate) { double n = ReadNum("FNum"); return double.IsNaN(n) ? 0 : (int)n; } }
 
         public static List<FanInfo> GetFans() {


### PR DESCRIPTION
added a human-readable sensor mapping layer in Smc.cs and updated App.cs to display mapped names for raw SMC keys.

Included T2 sensor mappings (tested on MacBookPro15,1):
- CPU Cores (TC1C..TC6C), System Agent (TCSA), PECI (TCXC), Core/Die (TCOE, TCOF)
- GPU Memory (TGDD), VRM (TGDF), Voltage (TGVP)
- Battery (TB1T, TB2T)
- Airflow (TF0S)
- NVMe SSD / Controller (TH0F, TH0X)

Raw SMC keys are preserved as a fallback if a mapping is missing.