### PR TITLE
Improve Menu & Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To **uninstall**, just delete the folder. Settings live in `%APPDATA%\RPMac`; if
 | Non-Apple PCs | Read-only (writes are blocked) |
 
 ### Tested hardware
-RPMac has been verified on **four machines**:
+RPMac has been verified on **five machines**:
 
 - **Mac Pro (Late 2013)** — model identifier `MacPro6,1`
   - Intel Xeon CPU, dual AMD FirePro GPUs, single centrifugal system fan

--- a/src/gui/App.cs
+++ b/src/gui/App.cs
@@ -2149,7 +2149,13 @@ namespace RPMac {
                 menu.Items.Add(trayPresetsItem);
                 menu.Items.Add("Toggle Overlay", null, delegate { ToggleOverlay(); });
                 menu.Items.Add("Quit", null, delegate { QuitApp(); });
+
                 tray.ContextMenuStrip = menu;
+                tray.MouseClick += delegate(object sender, System.Windows.Forms.MouseEventArgs e) {
+                    if (e.Button == System.Windows.Forms.MouseButtons.Left)
+                        menu.Show(System.Windows.Forms.Cursor.Position);
+                };
+
                 UpdateTrayPresets();
             } catch { }
         }

--- a/src/gui/App.cs
+++ b/src/gui/App.cs
@@ -2440,6 +2440,10 @@ namespace RPMac {
         // Aplica al abrir la última configuración guardada (si es seguro escribir)
         void ApplySaved() {
             if (!Smc.WritesAllowed) return;
+            if (!string.IsNullOrEmpty(Settings.ActivePreset) && Settings.Presets.ContainsKey(Settings.ActivePreset)) {
+                ApplyPreset(Settings.ActivePreset);
+                return;
+            }
             foreach (var f in fans) {
                 if (!Settings.Fans.ContainsKey(f.Index)) continue;
                 ApplyFanState(f, Settings.Fans[f.Index]);
@@ -2622,8 +2626,9 @@ namespace RPMac {
                 ApplyFanState(f, s);
                 Settings.Fans[f.Index] = s;   // also becomes the current saved state
             }
-            Settings.Save();
             activePreset = name;
+            Settings.ActivePreset = name;
+            Settings.Save();
             RebuildPresetChips();             // highlight the active one
             UpdateTrayPresets();
             status.Text = "Applied preset: " + name;
@@ -2635,9 +2640,10 @@ namespace RPMac {
             var snap = new Dictionary<int, string[]>();
             foreach (var f in fans) snap[f.Index] = FanStateToArray(f);
             Settings.Presets[name] = snap;
-            Settings.Save();
             presetNameBox.Text = "";
             activePreset = name;              // the just-saved config is now the active preset
+            Settings.ActivePreset = name;
+            Settings.Save();
             RebuildPresetChips();
             UpdateTrayPresets();
             status.Text = "Saved preset: " + name;
@@ -2645,7 +2651,7 @@ namespace RPMac {
 
         void DeletePreset(string name) {
             if (Settings.Presets.Remove(name)) {
-                if (activePreset == name) activePreset = null;
+                if (activePreset == name) { activePreset = null; Settings.ActivePreset = null; }
                 Settings.Save();
                 RebuildPresetChips();
                 UpdateTrayPresets();
@@ -2657,6 +2663,8 @@ namespace RPMac {
         void ClearActivePreset() {
             if (activePreset == null) return;
             activePreset = null;
+            Settings.ActivePreset = null;
+            Settings.Save();
             RebuildPresetChips();
             UpdateTrayPresets();
         }
@@ -2983,6 +2991,7 @@ namespace RPMac {
         public static Dictionary<int, string[]> Fans = new Dictionary<int, string[]>();
         // preset name -> (fan index -> saved state), same state form as Fans
         public static Dictionary<string, Dictionary<int, string[]>> Presets = new Dictionary<string, Dictionary<int, string[]>>();
+        public static string ActivePreset = null;
         public static bool StartMinimized = false;
         public static bool Fahrenheit = false;
         public static bool Overlay = false;
@@ -3024,6 +3033,7 @@ namespace RPMac {
                     else if (s.Length >= 2 && s[0] == "ovsel") OverlayItems = new HashSet<string>(s[1].Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries));
                     else if (s.Length >= 2 && s[0] == "theme") Theme = s[1];
                     else if (s.Length >= 2 && s[0] == "traymode") TrayMode = s[1];
+                    else if (s.Length >= 2 && s[0] == "activepreset") ActivePreset = s[1];
                     else if (s.Length >= 2 && s[0] == "smooth") Smoothing = (s[1] == "1");
                     else if (s.Length >= 2 && s[0] == "guard") SafetyGuard = (s[1] == "1");
                     else if (s.Length >= 2 && s[0] == "guardtemp") { int g; if (int.TryParse(s[1], out g) && g >= 60 && g <= 105) GuardTemp = g; }
@@ -3073,6 +3083,7 @@ namespace RPMac {
                 if (OverlayItems != null) lines.Add("ovsel|" + string.Join(",", new List<string>(OverlayItems).ToArray()));
                 lines.Add("theme|" + Theme);
                 lines.Add("traymode|" + TrayMode);
+                if (!string.IsNullOrEmpty(ActivePreset)) lines.Add("activepreset|" + ActivePreset.Replace("|", " "));
                 lines.Add("smooth|" + (Smoothing ? "1" : "0"));
                 lines.Add("guard|" + (SafetyGuard ? "1" : "0"));
                 lines.Add("guardtemp|" + GuardTemp);

--- a/src/gui/App.cs
+++ b/src/gui/App.cs
@@ -2147,6 +2147,7 @@ namespace RPMac {
                 menu.Items.Add("Open", null, delegate { ShowFromTray(); });
                 trayPresetsItem = new System.Windows.Forms.ToolStripMenuItem("Presets");
                 menu.Items.Add(trayPresetsItem);
+                menu.Items.Add("Toggle Overlay", null, delegate { ToggleOverlay(); });
                 menu.Items.Add("Quit", null, delegate { QuitApp(); });
                 tray.ContextMenuStrip = menu;
                 UpdateTrayPresets();
@@ -2815,6 +2816,7 @@ namespace RPMac {
             overlay.BringTopmost();
         }
         void HideOverlay() { if (overlay != null) overlay.Hide(); }
+        void ToggleOverlay() { if (overlay == null) ShowOverlay(); else HideOverlay(); }
 
         // ¿Mostrar este item en el overlay? (null = todo)
         static bool OverlaySel(string key) {

--- a/src/gui/App.cs
+++ b/src/gui/App.cs
@@ -2153,7 +2153,7 @@ namespace RPMac {
                 tray.ContextMenuStrip = menu;
                 tray.MouseClick += delegate(object sender, System.Windows.Forms.MouseEventArgs e) {
                     if (e.Button == System.Windows.Forms.MouseButtons.Left)
-                        menu.Show(System.Windows.Forms.Cursor.Position);
+                        ShowFromTray();
                 };
 
                 UpdateTrayPresets();

--- a/src/gui/App.cs
+++ b/src/gui/App.cs
@@ -2830,7 +2830,12 @@ namespace RPMac {
             overlay.BringTopmost();
         }
         void HideOverlay() { if (overlay != null) overlay.Hide(); }
-        void ToggleOverlay() { if (overlay == null) ShowOverlay(); else HideOverlay(); }
+        void ToggleOverlay() {
+            bool visible = overlay != null && overlay.IsVisible;
+            Settings.Overlay = !visible;
+            Settings.Save();
+            if (Settings.Overlay) ShowOverlay(); else HideOverlay();
+        }
 
         // ¿Mostrar este item en el overlay? (null = todo)
         static bool OverlaySel(string key) {


### PR DESCRIPTION
Changes:
1. Creates an overlay function in menu to enable/disable overlay
2. Fix a minor issue in the README
3. Automatically apply the preset the machine previously was in if the app quits
4. Make the app jump out of tray (show window) when left-clicking, like other apps do